### PR TITLE
User defined file name 

### DIFF
--- a/ionerdss/nerdss_analysis/analysis.py
+++ b/ionerdss/nerdss_analysis/analysis.py
@@ -54,6 +54,7 @@ class Analysis:
         y: str = "species",
         z: str = None,
         legend: list = None,
+        user_file_name: str = None,
         bins: int = 10,
         time_bins: int = 10,
         time_frame: tuple = None,
@@ -84,7 +85,8 @@ class Analysis:
             z (str, optional): Variable for the z-axis (only used in "3dhist" and "heatmap").
             
             legend (list, optional): Labels for the legend. If None, uses default labels.
-
+            user_file_name(str, optional): gives the option of saving .csv output with a specific name. 
+                Avoids save error for csvs plot_line_speciescopy_vs_time due to length. 
             bins (int): Number of bins for histograms. Default is 10.
             time_bins (int): Number of time bins for time-based 3d histograms. Default is 10.
             time_frame (tuple, optional): Time frame for the histogram. Default is None (uses full range).
@@ -150,6 +152,7 @@ class Analysis:
                 save_dir=self.save_dir,
                 simulations_index=simulations,
                 legend=legend,
+                user_file_name=user_file_name,
                 show_type=show_type,
                 simulations_dir=self.simulation_dirs,
                 figure_size=figure_size

--- a/ionerdss/nerdss_analysis/plot_figures.py
+++ b/ionerdss/nerdss_analysis/plot_figures.py
@@ -12,6 +12,7 @@ def plot_line_speciescopy_vs_time(
     save_dir: str,
     simulations_index: list,
     legend: list,
+    user_file_name: str = None,
     show_type: str = "both",
     simulations_dir: list = None,
     figure_size: tuple = (10, 6)
@@ -26,6 +27,8 @@ def plot_line_speciescopy_vs_time(
             - [['A(A1!1).A(A1!1)']] → plot 'A(A1!1).A(A1!1)'
             - [['A(A1!1).A(A1!1)'], ['A(A2!1).A(A2!1)']] → plot two species separately
             - [['A(A1!1).A(A1!1)', 'A(A2!1).A(A2!1)']] → plot their sum
+        user_file_name(str): user defined file name for csv output, anything greater than 100
+            will return an error(can be adjusted, line 83) 
         show_type (str): Display mode, "both", "individuals", or "average".
         simulations_dir (list, optional): List of directories for each simulation.
         figure_size (tuple): Size of the plot figure.
@@ -76,7 +79,16 @@ def plot_line_speciescopy_vs_time(
 
     # Save processed data
     for species, data in species_data.items():
-        save_path = os.path.join(plot_data_dir, f"{species.replace('+', '_')}.csv")
+        #checks whether file name is too long. will throw an OSerror if its too long
+        if len(f"{species.replace('+', '_')}") > 100:
+            print("Error: Generated File Name Too Long. Define a file name using the plot_figure optional argument user_file_name.")
+            return
+        #if file name is not too long and there is no user-defined name, autogenerates a file name
+        if user_file_name == None:
+            save_path = os.path.join(plot_data_dir, f"{species.replace('+', '_')}.csv")
+        #uses user_file_name to name the .csv output
+        else:
+            save_path = os.path.join(plot_data_dir,f"{user_file_name}.csv")
         df_to_save = pd.DataFrame({
             "Time (s)": time_values,
             "Mean": data["mean"],

--- a/ionerdss/nerdss_analysis/plot_figures.py
+++ b/ionerdss/nerdss_analysis/plot_figures.py
@@ -80,7 +80,7 @@ def plot_line_speciescopy_vs_time(
     # Save processed data
     for species, data in species_data.items():
         #checks whether file name is too long. will throw an OSerror if its too long
-        if len(f"{species.replace('+', '_')}") > 100:
+        if len(f"{species.replace('+', '_')}") > 100 and user_file_name == None:
             print("Error: Generated File Name Too Long. Define a file name using the plot_figure optional argument user_file_name.")
             return
         #if file name is not too long and there is no user-defined name, autogenerates a file name


### PR DESCRIPTION
Added an optional argument as user_file_name in plot_figures() to define a file name for the copyspecies_vs_time plot.  

Ran into an issue where the .csv data output would have too long of a name. Will throw an error and tell the user to use the optional argument if the file name is found to be greater than 100 characters. 