### PR TITLE
Update unittest.yml with coverage, caching, OS/version matrix

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,21 @@
+# Validate any edits:  curl -X POST --data-binary @.codecov.yml https://codecov.io/validate
+coverage:
+  precision: 2          # show XX.XX %
+  round: down           # 89.987 → 89.98 %
+  status:               # ← GitHub “Checks”
+    project:
+      default:
+        informational: true    # non‑blocking overall coverage  
+        target: auto           # compare to base commit 
+        threshold: 1%          # allow ±1 pp drift
+    patch:
+      default:
+        informational: true    # non‑blocking diff coverage 
+        target: 80%            # want 80 % on changed lines
+        threshold: 1%
+
+comment:
+  layout: "diff, flags, files"   # keep Codecov’s 3‑panel comment
+  behavior: default              # update a single comment per PR
+  require_head: true             # ensure CI actually uploaded a report
+  hide_project_coverage: false   # ← show project delta in the PR comment 

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -72,6 +72,15 @@ jobs:
                  --cov-report=xml \
                  --junitxml=report.xml
 
+      - name: Summarise failing tests
+        if: always()                    # still runs on failures
+        uses: pmeier/pytest-results-action@v0.7.1   # latest tag :contentReference[oaicite:5]{index=5}
+        with:
+          path: report.xml              # JUnit file(s) or glob
+          summary: true                 # add high‑level counts
+          display-options: fEX          # show failed, errored, x‑passed
+          title: "Test Results"
+
       #Junit is standard machine readable test output that can then be analyzed by various tools later, we upload as artifact to allow inspection
       - name: Upload JUnit report
         if: always()

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-20.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ['3.9', '3.11', '3.13']  
 
     steps:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,50 +1,88 @@
-name: Run Unit Tests
+name: Unit Tests & Coverage
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
     paths:
       - "ionerdss/**"
       - "tests/**"
       - ".github/workflows/unittest.yml"
   pull_request:
-    branches:
-      - main
+    branches: [main]
     paths:
       - "ionerdss/**"
       - "tests/**"
       - ".github/workflows/unittest.yml"
 
+#Stop redundant CI runs for superseded commits
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read            # needed by checkout
+  id-token: write           # required for Codecov OIDC uploads
+
 jobs:
   test:
-    runs-on: ubuntu-latest
+    name: ${{ matrix.os }} • Py ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-20.04, macos-latest]
+        python-version: ['3.9', '3.11', '3.13']  
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4       
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5    
         with:
-          python-version: "3.9"
+          python-version: ${{ matrix.python-version }}
+          cache: pip                       # built‑in dependency+wheel cache
+          cache-dependency-path: env/requirements.txt
 
-      - name: Install system dependencies (Qt, OpenGL, EGL)
-        run: |
-          sudo apt update
-          sudo apt install -y libegl1 libopengl0 libgl1-mesa-dev libxkbcommon-x11-0 qt6-base-dev
+      #Extra cache layer: pre‑built wheels in ~/.cache/pip so can work between OS/versions
+      - name: Cache compiled pip wheels
+        uses: actions/cache@v4             
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('env/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}
+            ${{ runner.os }}-pip-
 
-      - name: Install Python dependencies
+      # Qt/OpenGL runtime (Linux only; no‑op elsewhere as stated in the action repo, mac shouldn't need it)
+      - uses: tlambert03/setup-qt-libs@v1
+
+      - name: Install project dependencies
         run: pip install -r env/requirements.txt
 
-      - name: Set PYTHONPATH
-        run: echo "PYTHONPATH=$PWD" >> $GITHUB_ENV
+      - name: Install package in editable mode
+        run: pip install -e .
 
-      - name: Install package (if setup.py exists)
+      - name: Configure headless Qt
+        run: echo "QT_QPA_PLATFORM=offscreen" >> $GITHUB_ENV   #avoids xcb/display errors, according to the web
+
+      - name: Run tests
         run: |
-          if [ -f "setup.py" ]; then
-            pip install -e .
-          fi
+          pytest tests \
+                 --cov=ionerdss --cov-branch \
+                 --cov-report=xml \
+                 --junitxml=report.xml
 
-      - name: Run unit tests
-        run: pytest tests --junitxml=report.xml
+      #Junit is standard machine readable test output that can then be analyzed by various tools later, we upload as artifact to allow inspection
+      - name: Upload JUnit report
+        if: always()
+        uses: actions/upload-artifact@v4    
+        with:
+          name: junit-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: report.xml
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5      
+        with:
+          use_oidc: true #required for tokenless apparently
+          fail_ci_if_error: true

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Summarise failing tests
         if: always()                    # still runs on failures
-        uses: pmeier/pytest-results-action@v0.7.1   # latest tag :contentReference[oaicite:5]{index=5}
+        uses: pmeier/pytest-results-action@v0.7.1   # latest tag 
         with:
           path: report.xml              # JUnit file(s) or glob
           summary: true                 # add high‑level counts

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -60,7 +60,7 @@ jobs:
         run: pip install -r env/requirements.txt
 
       - name: Install package in editable mode
-        run: pip install -e .
+        run: pip install -e .[tests] # optional pytest/pytest-cov deps as defined in toml file
 
       - name: Configure headless Qt
         run: echo "QT_QPA_PLATFORM=offscreen" >> $GITHUB_ENV   #avoids xcb/display errors, according to the web

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,13 @@ dependencies = [
     "requests",
     "ipympl",
     "jupyter",
-    "jupyterlab",
     "notebook"
+]
+
+[project.optional-dependencies]
+tests = [
+  "pytest",
+  "pytest-cov",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
Made a variety of improvements based on my test workflows from other repos:
1. Matrix to test across common OS's and python versions users are likely to have
2. Updated versions for some actions or used updated syntax 
3. Adding caching to speed up repeat runs
4. Added Codecov code coverage monitoring, which I installed for our organization. Seen used on a lot of other packages

Note: Included Qt/OpenGL installation as before, even though no current tests need them. Using an existing action from `tlambert03/setup-qt-libs@v1` instead of manual