### PR TITLE
Refactored histogram and copynumber data processing

### DIFF
--- a/ionerdss/nerdss_analysis/__init__.py
+++ b/ionerdss/nerdss_analysis/__init__.py
@@ -23,6 +23,39 @@ Usage:
                         legend=[["A"], ["B"]], simulations=[0,1,2])
 """
 
+# =====================================================================
+# Development Note
+# 2025.06.11 
+# Mankun Sang
+# 
+# Histogram reading and Copynumber reading now have a unified 
+# reading pipeline: Processor.read().
+# Transition matrix reading is not modified.
+# TODO: Based on Histogram reading and Copynumber reading, further 
+# develop data reading for other output files including transition 
+# matrix.
+# TODO: The goal is to remove dependency on DataIO which is a legacy 
+# from the previous refactoring. It violates the structure of analysis 
+# module. The structure should be:
+# \_
+#   |_ __init__.py (handel import)
+#   |_ analysis.py (basic Analysis class)
+#   |_ plot_figures.py (basic plotting class)
+#   |_
+#   |_ data
+#       |_ __init__.py
+#       |_ core.py (data handling class)
+#       |_ processors
+#            |_ data reading modules, each output file has a module
+#            |_ ...
+#   |_ plotting
+#       |_ plotting modules, each type of figure has a module
+#       |_ ...
+#   |_ legacy
+#       |_ API for backward compatibility
+#       |_ ...
+# =====================================================================
+
 # Main interface
 from .analysis import Analysis
 
@@ -142,21 +175,3 @@ free_energy = data.get_free_energy_landscape()
 For detailed documentation, see individual class and method docstrings.
     """
     return help_text.strip()
-
-# Convenience function for quick analysis
-def quick_analysis(simulation_dir: str, **kwargs):
-    """
-    Quick analysis setup for common use cases.
-    
-    Parameters:
-        simulation_dir (str): Path to simulation directory
-        **kwargs: Additional Analysis initialization parameters
-        
-    Returns:
-        Analysis: Configured Analysis object
-        
-    Example:
-        analysis = ion.quick_analysis("/path/to/sims")
-        analysis.plot_figure(figure_type="line", x="time", y="species", legend=[["A"]])
-    """
-    return Analysis(simulation_dir, **kwargs)

--- a/ionerdss/nerdss_analysis/analysis.py
+++ b/ionerdss/nerdss_analysis/analysis.py
@@ -32,6 +32,9 @@ class Analysis:
         self.data = Data()
         self.plot = PlotConfigure(self.save_dir)
         self._legacy = LegacyPlotInterface(self)
+        
+        # Configure data reading by default with all possibile directories
+        self.get_data()
     
     def _discover_simulations(self):
         """Discover simulation directories containing DATA folders."""

--- a/ionerdss/nerdss_analysis/data/core.py
+++ b/ionerdss/nerdss_analysis/data/core.py
@@ -77,7 +77,7 @@ class Data:
             return self._cache[cache_key]
         
         # Load raw data
-        all_data = self.histogram.read_multiple(self._selected_dirs, self._config)
+        all_data = self.histogram.read(self._selected_dirs, self._config)
         
         # Process and structure data
         result = {

--- a/ionerdss/nerdss_analysis/data/core.py
+++ b/ionerdss/nerdss_analysis/data/core.py
@@ -9,6 +9,8 @@ import hashlib
 from typing import List, Optional, Dict, Any, Tuple
 from .processors import HistogramProcessor, CopyNumberProcessor, TransitionProcessor
 
+from .processors.utils import align_time_series
+
 
 class Data:
     """
@@ -72,12 +74,12 @@ class Data:
             return self._cache[cache_key]
         
         # Load raw data
-        all_data = self.histogram.read_multiple(self._selected_dirs)
+        all_data = self.histogram.read_multiple(self._selected_dirs, self._config)
         
         # Process and structure data
         result = {
             'raw_data': all_data,
-            'time_series': self._align_time_series(all_data),
+            'time_series': align_time_series(all_data),
             'species_filter': self._config['species'],
             'metadata': {
                 'num_simulations': len(all_data),
@@ -89,122 +91,124 @@ class Data:
         self._cache[cache_key] = result
         return result
     
-    def get_copy_numbers_data(self, **kwargs) -> Dict[str, Any]:
-        """Get processed copy numbers data with enhanced processing."""
-        cache_key = self._generate_cache_key('copy_numbers', **kwargs)
+    # def get_copy_numbers_data(self, **kwargs) -> Dict[str, Any]:
+    #     """Get processed copy numbers data with enhanced processing."""
+    #     cache_key = self._generate_cache_key('copy_numbers', **kwargs)
         
-        if cache_key in self._cache:
-            return self._cache[cache_key]
+    #     if cache_key in self._cache:
+    #         return self._cache[cache_key]
         
-        # Load raw data
-        dataframes = []
-        for sim_dir in self._selected_dirs:
-            df = self._data_io.get_copy_numbers(sim_dir)
-            if df is not None:
-                dataframes.append(df)
+    #     # Load raw data
+    #     dataframes = []
+    #     for sim_dir in self._selected_dirs:
+    #         df = self._data_io.get_copy_numbers(sim_dir)
+    #         if df is not None:
+    #             dataframes.append(df)
         
-        # Process data
-        result = {
-            'dataframes': dataframes,
-            'aligned_data': self.copy_numbers.align_time_series({'dataframes': dataframes}),
-            'species_filter': self._config['species'],
-            'metadata': {
-                'num_simulations': len(dataframes),
-                'cache_key': cache_key
-            }
-        }
+    #     # Process data
+    #     result = {
+    #         'dataframes': dataframes,
+    #         'aligned_data': self.copy_numbers.align_time_series({'dataframes': dataframes}),
+    #         'species_filter': self._config['species'],
+    #         'metadata': {
+    #             'num_simulations': len(dataframes),
+    #             'cache_key': cache_key
+    #         }
+    #     }
         
-        self._cache[cache_key] = result
-        return result
+    #     self._cache[cache_key] = result
+    #     return result
     
-    def get_transition_data(self, **kwargs) -> Dict[str, Any]:
-        """Get processed transition matrix and lifetime data."""
-        cache_key = self._generate_cache_key('transition', **kwargs)
+    # def get_transition_data(self, **kwargs) -> Dict[str, Any]:
+    #     """Get processed transition matrix and lifetime data."""
+    #     cache_key = self._generate_cache_key('transition', **kwargs)
         
-        if cache_key in self._cache:
-            return self._cache[cache_key]
+    #     if cache_key in self._cache:
+    #         return self._cache[cache_key]
         
-        # Load raw data
-        matrices = []
-        lifetimes = []
-        for sim_dir in self._selected_dirs:
-            matrix, lifetime = self._data_io.get_transition_matrix(sim_dir, self._config['time_frame'])
-            if matrix is not None:
-                matrices.append(matrix)
-                lifetimes.append(lifetime)
+    #     # Load raw data
+    #     matrices = []
+    #     lifetimes = []
+    #     for sim_dir in self._selected_dirs:
+    #         matrix, lifetime = self._data_io.get_transition_matrix(sim_dir, self._config['time_frame'])
+    #         if matrix is not None:
+    #             matrices.append(matrix)
+    #             lifetimes.append(lifetime)
         
-        result = {
-            'matrices': matrices,
-            'lifetimes': lifetimes,
-            'aggregated_matrix': self.transitions.aggregate_matrices({'matrices': matrices}),
-            'metadata': {
-                'num_simulations': len(matrices),
-                'time_frame': self._config['time_frame'],
-                'cache_key': cache_key
-            }
-        }
+    #     result = {
+    #         'matrices': matrices,
+    #         'lifetimes': lifetimes,
+    #         'aggregated_matrix': self.transitions.aggregate_matrices({'matrices': matrices}),
+    #         'metadata': {
+    #             'num_simulations': len(matrices),
+    #             'time_frame': self._config['time_frame'],
+    #             'cache_key': cache_key
+    #         }
+    #     }
         
-        self._cache[cache_key] = result
-        return result
+    #     self._cache[cache_key] = result
+    #     return result
     
-    # Enhanced methods using processors
-    def get_time_series_statistics(self, legends: List[List[str]], **kwargs):
-        """Get time series statistics for multiple legends."""
-        histogram_data = self.get_histogram_data(**kwargs)
-        return self.histogram.calculate_time_series_statistics(histogram_data, legends)
+    # # Enhanced methods using processors
+    # def get_time_series_statistics(self, legends: List[List[str]], **kwargs):
+    #     """Get time series statistics for multiple legends."""
+    #     histogram_data = self.get_histogram_data(**kwargs)
+    #     return self.histogram.calculate_time_series_statistics(histogram_data, legends)
 
-    def get_complex_sizes(self, legend: List[str], **kwargs) -> List[List[int]]:
-        """Extract complex sizes using histogram processor."""
-        histogram_data = self.get_histogram_data(**kwargs)
-        return self.histogram.calculate_complex_sizes(histogram_data, legend)
+    # def get_complex_sizes(self, legend: List[str], **kwargs) -> List[List[int]]:
+    #     """Extract complex sizes using histogram processor."""
+    #     histogram_data = self.get_histogram_data(**kwargs)
+    #     return self.histogram.calculate_complex_sizes(histogram_data, legend)
     
-    def get_size_distribution_stats(self, legend: List[str], **kwargs) -> Dict[str, float]:
-        """Get statistical measures of complex size distribution."""
-        histogram_data = self.get_histogram_data(**kwargs)
-        return self.histogram.get_size_distribution_stats(histogram_data, legend)
+    # def get_size_distribution_stats(self, legend: List[str], **kwargs) -> Dict[str, float]:
+    #     """Get statistical measures of complex size distribution."""
+    #     histogram_data = self.get_histogram_data(**kwargs)
+    #     return self.histogram.get_size_distribution_stats(histogram_data, legend)
     
-    def get_species_trends(self, species_groups: List[List[str]], **kwargs) -> Dict[str, Dict[str, Any]]:
-        """Get time series trends for species groups."""
-        copy_data = self.get_copy_numbers_data(**kwargs)
-        return self.copy_numbers.calculate_trends(copy_data, species_groups)
+    # def get_species_trends(self, species_groups: List[List[str]], **kwargs) -> Dict[str, Dict[str, Any]]:
+    #     """Get time series trends for species groups."""
+    #     copy_data = self.get_copy_numbers_data(**kwargs)
+    #     return self.copy_numbers.calculate_trends(copy_data, species_groups)
     
-    def get_equilibrium_analysis(self, species_groups: List[List[str]], **kwargs) -> Dict[str, Any]:
-        """Get equilibrium analysis for species groups."""
-        copy_data = self.get_copy_numbers_data(**kwargs)
+    # def get_equilibrium_analysis(self, species_groups: List[List[str]], **kwargs) -> Dict[str, Any]:
+    #     """Get equilibrium analysis for species groups."""
+    #     copy_data = self.get_copy_numbers_data(**kwargs)
         
-        return {
-            'equilibrium_periods': self.copy_numbers.find_equilibrium_points(copy_data, species_groups),
-            'time_to_equilibrium': self.copy_numbers.calculate_time_to_equilibrium(copy_data, species_groups),
-            'statistics': self.copy_numbers.compute_statistics(copy_data, species_groups)
-        }
+    #     return {
+    #         'equilibrium_periods': self.copy_numbers.find_equilibrium_points(copy_data, species_groups),
+    #         'time_to_equilibrium': self.copy_numbers.calculate_time_to_equilibrium(copy_data, species_groups),
+    #         'statistics': self.copy_numbers.compute_statistics(copy_data, species_groups)
+    #     }
     
-    def get_free_energy_landscape(self, **kwargs) -> Dict[str, Any]:
-        """Get free energy landscape from transition data."""
-        transition_data = self.get_transition_data(**kwargs)
-        return self.transitions.calculate_free_energy(transition_data)
+    # def get_free_energy_landscape(self, **kwargs) -> Dict[str, Any]:
+    #     """Get free energy landscape from transition data."""
+    #     transition_data = self.get_transition_data(**kwargs)
+    #     return self.transitions.calculate_free_energy(transition_data)
     
-    def get_pathway_analysis(self, **kwargs) -> Dict[str, Any]:
-        """Get comprehensive pathway analysis."""
-        transition_data = self.get_transition_data(**kwargs)
+    # def get_pathway_analysis(self, **kwargs) -> Dict[str, Any]:
+    #     """Get comprehensive pathway analysis."""
+    #     transition_data = self.get_transition_data(**kwargs)
         
-        return {
-            'association_probs': self.transitions.calculate_association_probabilities(transition_data),
-            'dissociation_probs': self.transitions.calculate_dissociation_probabilities(transition_data),
-            'growth_probs': self.transitions.calculate_growth_probabilities(transition_data),
-            'dominant_pathways': self.transitions.find_dominant_pathways(transition_data),
-            'pathway_flux': self.transitions.calculate_pathway_flux(transition_data)
-        }
+    #     return {
+    #         'association_probs': self.transitions.calculate_association_probabilities(transition_data),
+    #         'dissociation_probs': self.transitions.calculate_dissociation_probabilities(transition_data),
+    #         'growth_probs': self.transitions.calculate_growth_probabilities(transition_data),
+    #         'dominant_pathways': self.transitions.find_dominant_pathways(transition_data),
+    #         'pathway_flux': self.transitions.calculate_pathway_flux(transition_data)
+    #     }
     
-    def get_lifetime_analysis(self, **kwargs) -> Dict[str, Any]:
-        """Get comprehensive lifetime analysis."""
-        transition_data = self.get_transition_data(**kwargs)
+    # def get_lifetime_analysis(self, **kwargs) -> Dict[str, Any]:
+    #     """Get comprehensive lifetime analysis."""
+    #     transition_data = self.get_transition_data(**kwargs)
         
-        return {
-            'lifetime_stats': self.transitions.calculate_lifetime_statistics(transition_data),
-            'aggregated_lifetimes': self.transitions.aggregate_lifetimes(transition_data)
-        }
+    #     return {
+    #         'lifetime_stats': self.transitions.calculate_lifetime_statistics(transition_data),
+    #         'aggregated_lifetimes': self.transitions.aggregate_lifetimes(transition_data)
+    #     }
     
+    # ============================================
     # Utility methods
+    # ============================================
     def _generate_cache_key(self, data_type: str, **kwargs) -> str:
         """Generate unique cache key based on configuration and parameters."""
         key_data = {
@@ -216,9 +220,6 @@ class Data:
         }
         key_str = str(sorted(key_data.items()))
         return hashlib.md5(key_str.encode()).hexdigest()[:12]
-    
-    
-    
     
     def clear_cache(self):
         """Clear all cached data and processor caches."""

--- a/ionerdss/nerdss_analysis/data/processors/copy_numbers.py
+++ b/ionerdss/nerdss_analysis/data/processors/copy_numbers.py
@@ -29,12 +29,19 @@ class CopyNumberProcessor:
     def configure(self, selected_dirs: List[str]):
         self._selected_dirs = selected_dirs
 
-    def read(self, selected_dirs, config) -> List[Dict[str, Any]]:
+    def read(self, selected_dirs, config = {"time_frame":None}) -> List[Dict[str, Any]]:
         """Decide to read multiple or read single"""
+
+        # parse selected directories
+        if not selected_dirs:
+            if not self._selected_dirs:
+                raise FileNotFoundError("No directory selected for reading.")
+            selected_dirs = self._selected_dirs
+
         if isinstance(selected_dirs, list):
-            return self.read_multiple(self, selected_dirs, config)
+            return self.read_multiple(selected_dirs, config), 'Multiple'
         elif isinstance(selected_dirs, str):
-            return self.read_single(selected_dirs)
+            return self.read_single(selected_dirs), 'Single'
     
     def read_single(self, sim_dir: str) -> Dict[str, Any]:
         """

--- a/ionerdss/nerdss_analysis/data/processors/copy_numbers.py
+++ b/ionerdss/nerdss_analysis/data/processors/copy_numbers.py
@@ -29,9 +29,12 @@ class CopyNumberProcessor:
     def configure(self, selected_dirs: List[str]):
         self._selected_dirs = selected_dirs
 
-    def read(self, selected_dirs: List[str]) -> List[Dict[str, Any]]:
-        """Nick name for read_multiple"""
-        return self.read_multiple(self, selected_dirs)
+    def read(self, selected_dirs, config) -> List[Dict[str, Any]]:
+        """Decide to read multiple or read single"""
+        if isinstance(selected_dirs, list):
+            return self.read_multiple(self, selected_dirs, config)
+        elif isinstance(selected_dirs, str):
+            return self.read_single(selected_dirs)
     
     def read_single(self, sim_dir: str) -> Dict[str, Any]:
         """

--- a/ionerdss/nerdss_analysis/data/processors/copy_numbers.py
+++ b/ionerdss/nerdss_analysis/data/processors/copy_numbers.py
@@ -17,6 +17,10 @@ class CopyNumberProcessor:
     
     def __init__(self):
         self._cache = {}
+        self._selected_dirs = []
+
+    def configure(self, selected_dirs: List[str]):
+        self._selected_dirs = selected_dirs
     
     def align_time_series(self, copy_data: Dict[str, Any]) -> Dict[str, Any]:
         """Align time series across multiple simulations to common time points."""

--- a/ionerdss/nerdss_analysis/data/processors/histogram.py
+++ b/ionerdss/nerdss_analysis/data/processors/histogram.py
@@ -33,9 +33,12 @@ class HistogramProcessor:
     def configure(self, selected_dirs: List[str]):
         self._selected_dirs = selected_dirs
 
-    def read(self, selected_dirs: List[str]) -> List[Dict[str, Any]]:
-        """Nick name for read_multiple"""
-        return self.read_multiple(self, selected_dirs)
+    def read(self, selected_dirs, config) -> List[Dict[str, Any]]:
+        """Decide to read multiple or read single"""
+        if isinstance(selected_dirs, list):
+            return self.read_multiple(self, selected_dirs, config)
+        elif isinstance(selected_dirs, str):
+            return self.read_single(selected_dirs)
     
     def read_single(self, sim_dir: str) -> Dict[str, Any]:
         """
@@ -140,10 +143,10 @@ class HistogramProcessor:
         all_sizes = []
         for data in histogram_data['raw_data']:
             sim_sizes = []
-            for complexes in data['complexes']:
-                for count, species_dict in complexes:
-                    size = sum(species_dict.get(s, 0) for s in legend if s in species_dict)
-                    sim_sizes.extend([size] * count)
+        for complexes in data["complexes"]:
+            for count, species_dict in complexes:
+                complex_size = sum(species_dict[species] for species in legend if species in species_dict)
+                sim_sizes.extend([complex_size] * count)
             all_sizes.append(sim_sizes)
         
         self._cache[cache_key] = all_sizes

--- a/ionerdss/nerdss_analysis/data/processors/histogram.py
+++ b/ionerdss/nerdss_analysis/data/processors/histogram.py
@@ -33,12 +33,19 @@ class HistogramProcessor:
     def configure(self, selected_dirs: List[str]):
         self._selected_dirs = selected_dirs
 
-    def read(self, selected_dirs, config) -> List[Dict[str, Any]]:
+    def read(self, selected_dirs, config = {"time_frame":None}) -> List[Dict[str, Any]]:
         """Decide to read multiple or read single"""
+
+        # parse selected directories
+        if not selected_dirs:
+            if not self._selected_dirs:
+                raise FileNotFoundError("No directory selected for reading.")
+            selected_dirs = self._selected_dirs
+
         if isinstance(selected_dirs, list):
-            return self.read_multiple(self, selected_dirs, config)
+            return self.read_multiple(selected_dirs, config), 'Multiple'
         elif isinstance(selected_dirs, str):
-            return self.read_single(selected_dirs)
+            return self.read_single(selected_dirs), 'Single'
     
     def read_single(self, sim_dir: str) -> Dict[str, Any]:
         """

--- a/ionerdss/nerdss_analysis/data/processors/histogram.py
+++ b/ionerdss/nerdss_analysis/data/processors/histogram.py
@@ -1,11 +1,21 @@
 """
 Histogram data processor for complex analysis.
 """
-
+import os
 import numpy as np
+import re
 import pandas as pd
 from typing import List, Dict, Any, Tuple, Optional
-from collections import defaultdict
+
+# Helper functions
+from utils import parse_histogram_complex, parse_histogram_line, filter_by_time_frame, align_time_series
+
+
+# Configure logging, 
+import logging
+# inherit from the global level (should be setup in main)
+logger = logging.getLogger(__name__)
+
 
 
 class HistogramProcessor:
@@ -18,7 +28,103 @@ class HistogramProcessor:
     
     def __init__(self):
         self._cache = {}
+        self._selected_dirs = []
+
+    def configure(self, selected_dirs: List[str]):
+        self._selected_dirs = selected_dirs
+
+    def read(self, selected_dirs: List[str]) -> List[Dict[str, Any]]:
+        """Nick name for read_multiple"""
+        return self.read_multiple(self, selected_dirs)
     
+    def read_single(sim_dir: str) -> Dict[str, Any]:
+        """
+        Read histogram complex data from a simulation directory.
+        
+        Parameters:
+            sim_dir (str): Path to the simulation directory
+            
+        Returns:
+            Dict[str, Any]: Dictionary containing time series and complex data
+        """
+        data_file = os.path.join(sim_dir, "DATA", "histogram_complexes_time.dat")
+        
+        if not os.path.exists(data_file):
+            logger.warning(f"Histogram complexes file not found: {data_file}")
+            return {"time_series": [], "complexes": []}
+        
+        time_series = []
+        all_complexes = []
+        
+        try:
+            with open(data_file, "r") as f:
+                lines = f.readlines()
+            
+            current_time = None
+            current_complexes = []
+            
+            for line_num, line in enumerate(lines, 1):
+                line = line.strip()
+                if not line:
+                    continue
+                    
+                time_match = re.match(r"Time \(s\): (\d*\.?\d+)", line)
+                if time_match:
+                    if current_time is not None:
+                        time_series.append(current_time)
+                        all_complexes.append(current_complexes)
+                        current_complexes = []
+                    
+                    current_time = float(time_match.group(1))
+                else:
+                    count, species_dict = parse_histogram_line(line)
+                    if species_dict:
+                        current_complexes.append((count, species_dict))
+                    elif line.strip() and not line.startswith('#'):
+                        logger.debug(f"Could not parse line {line_num}: {line}")
+            
+            # Add the last time point
+            if current_time is not None and current_complexes:
+                time_series.append(current_time)
+                all_complexes.append(current_complexes)
+            
+            logger.debug(f"Successfully read histogram complexes from {data_file}")
+            
+        except Exception as e:
+            logger.error(f"Error reading histogram complexes from {data_file}: {e}")
+            return {"time_series": [], "complexes": []}
+        
+        return {
+            "time_series": time_series,
+            "complexes": all_complexes
+        }
+
+    def read_multiple(self, selected_dirs: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+        """read multiple files"""
+
+        # check cache
+        cache_key = "raw_data"
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+        
+        if not selected_dirs:
+            if not self._selected_dirs:
+                raise FileNotFoundError("No directory selected for reading.")
+            selected_dirs = self._selected_dirs
+
+        # Load raw data
+        all_data = []
+        for sim_dir in selected_dirs:
+            data = self.read(sim_dir)
+            if data["time_series"]:
+                if self._config['time_frame']:
+                    data = filter_by_time_frame(data, self._config['time_frame'])
+                all_data.append(data)
+
+        self._cache[cache_key] = all_data
+
+        return all_data
+
     def calculate_complex_sizes(self, 
                               histogram_data: Dict[str, Any], 
                               legend: List[str]) -> List[List[int]]:
@@ -59,11 +165,12 @@ class HistogramProcessor:
             'min': int(np.min(sizes_array)),
             'total_complexes': len(combined_sizes)
         }
+    
+    def get_time_series(self, 
+                        legends: List[List[str]],
+                        legend_names: Optional[List[str]] = None
+        ) -> pd.DataFrame:
 
-    def calculate_time_series_statistics(self, 
-                                       histogram_data: Dict[str, Any], 
-                                       legends: List[List[str]],
-                                       legend_names: Optional[List[str]] = None) -> pd.DataFrame:
         """
         Calculate time series statistics (mean, std, median) for different legends.
         
@@ -73,9 +180,95 @@ class HistogramProcessor:
         Parameters:
             histogram_data (Dict[str, Any]): Processed histogram data from get_histogram_data()
             legends (List[List[str]]): List of legend definitions, where each legend is a list of species.
-                Example: [["A"], ["B"], ["A", "B"]] for separate A, B, and combined A+B analysis
-            legend_names (Optional[List[str]]): Custom names for each legend. If None, auto-generated.
-                Example: ["Species_A", "Species_B", "Combined_AB"]
+                Example: ["A: 1.", "B: 2.", "A: 3. B: 4."] for separate A, B, and combined A+B analysis
+            legend_names (Optional[List[str]]): Custom names for each legend. If None, use legends.
+                Example: ["A1", "B2", "A3B4"]
+        
+        Returns:
+            pd.DataFrame: DataFrame with columns:
+                - Time (s): Time points
+                - For each legend: Each trajectory's data for aligned time points
+                
+        Example:
+            # Get time series statistics for individual and combined species
+            legends = ["A: 1.", "B: 2.", "A: 3. B: 4."]
+            legend_names = ["A1", "B2", "A3B4"]
+            stats_df = processor.get_time_series(data, legends, legend_names)
+        """
+        cache_key = f"time_series_{hash(tuple(tuple(leg) for leg in legends))}"
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+        
+        cache_key = f"raw_data"
+        if cache_key in self._cache:
+            raw_data = self._cache[cache_key]
+        else:
+            logger.warning("No data read. Start reading...")
+            try:
+                raw_data = self.read_multiple()
+            except Exception as e:
+                logger.error(f"No data provided: {e}")
+        
+        # Generate legend names if not provided
+        if legend_names is None:
+            legend_names = legends
+        
+        if len(legend_names) != len(legends):
+            raise ValueError("Number of legend_names must match number of legends")
+        
+        legend_dicts = [parse_histogram_complex(l) for l in legends]
+        
+        common_time_points = align_time_series(raw_data)
+        min_length = len(common_time_points)
+        
+        # Initialize result dictionary
+        result_data = {'Time (s)': common_time_points}
+        for ldict in legend_dicts:
+            result_data[ldict] = [] # all data points
+        
+        # Process over all data
+            
+        for data in raw_data:
+            if not data['time_series'] or len(data['time_series']) < min_length:
+                logger.critical(f"Illegal time_series. This should not happen. Min length calculated is {min_length}. \n" +
+                                f"This time series has length {len(data['time_series'])}")
+                continue
+                
+            time_series = {}
+            for ldict in legend_dicts:
+                time_series[ldict] = []
+
+            for time_idx in range(min_length):
+                complexes = data['complexes'][time_idx]
+                
+                # Calculate sizes for all complexes at this time point
+                sizes_at_time = []
+                for count, species_dict in complexes:
+                    if species_dict in legend_dicts:
+                        time_series[ldict].append(count)
+            
+            result_data[ldict].append(time_series[ldict])
+
+        self._cache[cache_key] = result_data
+
+        return result_data
+        
+
+    def calculate_time_series_statistics(self, 
+                                       legends: List[List[str]],
+                                       legend_names: Optional[List[str]] = None) -> Dict[Dict,Any]:
+        """
+        Calculate time series statistics (mean, std, median) for different legends.
+        
+        This method processes histogram data across multiple simulations and time points
+        to generate statistical measures for each legend over time.
+        
+        Parameters:
+            histogram_data (Dict[str, Any]): Processed histogram data from get_histogram_data()
+            legends (List[List[str]]): List of legend definitions, where each legend is a list of species.
+                Example: ["A: 1.", "B: 2.", "A: 3. B: 4."] for separate A, B, and combined A+B analysis
+            legend_names (Optional[List[str]]): Custom names for each legend. If None, use legends.
+                Example: ["A1", "B2", "A3B4"]
         
         Returns:
             pd.DataFrame: DataFrame with columns:
@@ -84,8 +277,8 @@ class HistogramProcessor:
                 
         Example:
             # Get time series statistics for individual and combined species
-            legends = [["A"], ["B"], ["A", "B"]]
-            legend_names = ["Species_A", "Species_B", "Combined_AB"]
+            legends = ["A: 1.", "B: 2.", "A: 3. B: 4."]
+            legend_names = ["A1", "B2", "A3B4"]
             stats_df = processor.calculate_time_series_statistics(data, legends, legend_names)
             
             # Results in DataFrame with columns:
@@ -97,268 +290,31 @@ class HistogramProcessor:
         if cache_key in self._cache:
             return self._cache[cache_key]
         
-        raw_data = histogram_data['raw_data']
-        if not raw_data:
-            return pd.DataFrame()
-        
-        # Generate legend names if not provided
-        if legend_names is None:
-            legend_names = []
-            for i, legend in enumerate(legends):
-                if len(legend) == 1:
-                    legend_names.append(f"Species_{legend[0]}")
-                else:
-                    legend_names.append(f"Combined_{'_'.join(legend)}")
-        
-        if len(legend_names) != len(legends):
-            raise ValueError("Number of legend_names must match number of legends")
-        
-        # Find common time points across all simulations
-        time_series_list = [data['time_series'] for data in raw_data if data['time_series']]
-        if not time_series_list:
-            return pd.DataFrame()
-        
-        # Use the shortest time series to ensure alignment
-        min_length = min(len(ts) for ts in time_series_list)
-        common_time_points = time_series_list[0][:min_length]
-        
-        # Initialize result dictionary
-        result_data = {'Time (s)': common_time_points}
-        
-        # Process each legend
-        for legend_idx, (legend, legend_name) in enumerate(zip(legends, legend_names)):
-            # Calculate complex sizes for each simulation at each time point
-            sim_time_series = []
+        try: # to get the time series
+            result_data = self.get_time_series(legends, legend_names)
+        except Exception as e:
+            logger.error("Error getting time series: {e}")
             
-            for data in raw_data:
-                if not data['time_series'] or len(data['time_series']) < min_length:
-                    continue
-                    
-                time_series = []
-                for time_idx in range(min_length):
-                    complexes = data['complexes'][time_idx]
-                    
-                    # Calculate sizes for all complexes at this time point
-                    sizes_at_time = []
-                    for count, species_dict in complexes:
-                        size = sum(species_dict.get(s, 0) for s in legend if s in species_dict)
-                        if size > 0:  # Only include non-zero sizes
-                            sizes_at_time.extend([size] * count)
-                    
-                    time_series.append(sizes_at_time)
-                
-                sim_time_series.append(time_series)
-            
-            if not sim_time_series:
-                # No valid data for this legend
-                result_data[f"{legend_name}_Mean"] = [0.0] * len(common_time_points)
-                result_data[f"{legend_name}_Std"] = [0.0] * len(common_time_points)
-                result_data[f"{legend_name}_Median"] = [0.0] * len(common_time_points)
-                continue
-            
-            # Calculate statistics across simulations for each time point
-            mean_series = []
-            std_series = []
-            median_series = []
-            
-            for time_idx in range(min_length):
-                # Collect all sizes from all simulations at this time point
-                all_sizes_at_time = []
-                
-                for sim_series in sim_time_series:
-                    if time_idx < len(sim_series):
-                        all_sizes_at_time.extend(sim_series[time_idx])
-                
-                if all_sizes_at_time:
-                    sizes_array = np.array(all_sizes_at_time)
-                    mean_series.append(float(np.mean(sizes_array)))
-                    std_series.append(float(np.std(sizes_array)))
-                    median_series.append(float(np.median(sizes_array)))
-                else:
-                    mean_series.append(0.0)
-                    std_series.append(0.0)
-                    median_series.append(0.0)
-            
-            # Add to result data
-            result_data[f"{legend_name}_Mean"] = mean_series
-            result_data[f"{legend_name}_Std"] = std_series
-            result_data[f"{legend_name}_Median"] = median_series
         
-        # Create DataFrame
-        stats_df = pd.DataFrame(result_data)
+        # Calculate statistics across simulations for each time point
+        result_stat = {'Time (s)': result_data['Time (s)']}
+        legend_names = [key for key in result_stat if key != 'Time (s)']
+        try:
+            for species in legend_names:
+                result_stat[species] = {
+                    'mean':np.mean(result_data[species], axis=0), 
+                    'std':np.std(result_data[species], axis=0), 
+                    'median':np.median(result_data[species], axis=0),
+                }
+        except Exception as e:
+            logger.error("Failed calculating stats: {e}")
         
         # Cache the result
-        self._cache[cache_key] = stats_df
+        self._cache[cache_key] = result_stat
         
-        return stats_df
-    
-    def calculate_aggregated_statistics(self, 
-                                      histogram_data: Dict[str, Any], 
-                                      legends: List[List[str]],
-                                      legend_names: Optional[List[str]] = None,
-                                      time_frame: Optional[Tuple[float, float]] = None) -> pd.DataFrame:
-        """
-        Calculate aggregated statistics for legends over a specified time frame.
-        
-        Parameters:
-            histogram_data (Dict[str, Any]): Processed histogram data
-            legends (List[List[str]]): List of legend definitions
-            legend_names (Optional[List[str]]): Custom names for legends
-            time_frame (Optional[Tuple[float, float]]): Time range to aggregate over (start, end)
-        
-        Returns:
-            pd.DataFrame: DataFrame with aggregated statistics for each legend
-        """
-        time_series_df = self.calculate_time_series_statistics(histogram_data, legends, legend_names)
-        
-        if time_series_df.empty:
-            return pd.DataFrame()
-        
-        # Filter by time frame if specified
-        if time_frame is not None:
-            start_time, end_time = time_frame
-            mask = (time_series_df['Time (s)'] >= start_time) & (time_series_df['Time (s)'] <= end_time)
-            filtered_df = time_series_df[mask]
-        else:
-            filtered_df = time_series_df
-        
-        if filtered_df.empty:
-            return pd.DataFrame()
-        
-        # Generate legend names if not provided
-        if legend_names is None:
-            legend_names = []
-            for legend in legends:
-                if len(legend) == 1:
-                    legend_names.append(f"Species_{legend[0]}")
-                else:
-                    legend_names.append(f"Combined_{'_'.join(legend)}")
-        
-        # Calculate aggregated statistics
-        agg_stats = []
-        for legend_name in legend_names:
-            mean_col = f"{legend_name}_Mean"
-            std_col = f"{legend_name}_Std"
-            median_col = f"{legend_name}_Median"
-            
-            if mean_col in filtered_df.columns:
-                stats = {
-                    'Legend': legend_name,
-                    'Overall_Mean': filtered_df[mean_col].mean(),
-                    'Overall_Std': filtered_df[std_col].mean(),
-                    'Overall_Median': filtered_df[median_col].mean(),
-                    'Time_Avg_Mean': filtered_df[mean_col].mean(),
-                    'Time_Avg_Std': filtered_df[mean_col].std(),
-                    'Max_Mean': filtered_df[mean_col].max(),
-                    'Min_Mean': filtered_df[mean_col].min(),
-                    'Final_Mean': filtered_df[mean_col].iloc[-1] if len(filtered_df) > 0 else 0,
-                    'Initial_Mean': filtered_df[mean_col].iloc[0] if len(filtered_df) > 0 else 0,
-                    'Data_Points': len(filtered_df)
-                }
-                agg_stats.append(stats)
-        
-        return pd.DataFrame(agg_stats)
-    
-    def export_time_series_statistics(self, 
-                                    histogram_data: Dict[str, Any], 
-                                    legends: List[List[str]],
-                                    output_path: str,
-                                    legend_names: Optional[List[str]] = None) -> str:
-        """
-        Export time series statistics to CSV file.
-        
-        Parameters:
-            histogram_data (Dict[str, Any]): Processed histogram data
-            legends (List[List[str]]): List of legend definitions
-            output_path (str): Path for output CSV file
-            legend_names (Optional[List[str]]): Custom names for legends
-        
-        Returns:
-            str: Path to the saved CSV file
-        """
-        stats_df = self.calculate_time_series_statistics(histogram_data, legends, legend_names)
-        
-        if stats_df.empty:
-            raise ValueError("No data available to export")
-        
-        # Ensure output directory exists
-        import os
-        os.makedirs(os.path.dirname(output_path), exist_ok=True)
-        
-        # Save to CSV
-        stats_df.to_csv(output_path, index=False)
-        
-        return output_path
-    
-    def get_legend_comparison_stats(self, 
-                                  histogram_data: Dict[str, Any], 
-                                  legends: List[List[str]],
-                                  legend_names: Optional[List[str]] = None) -> Dict[str, Any]:
-        """
-        Compare statistics between different legends.
-        
-        Parameters:
-            histogram_data (Dict[str, Any]): Processed histogram data
-            legends (List[List[str]]): List of legend definitions to compare
-            legend_names (Optional[List[str]]): Custom names for legends
-        
-        Returns:
-            Dict[str, Any]: Comparison statistics between legends
-        """
-        time_series_df = self.calculate_time_series_statistics(histogram_data, legends, legend_names)
-        
-        if time_series_df.empty:
-            return {}
-        
-        # Generate legend names if not provided
-        if legend_names is None:
-            legend_names = []
-            for legend in legends:
-                if len(legend) == 1:
-                    legend_names.append(f"Species_{legend[0]}")
-                else:
-                    legend_names.append(f"Combined_{'_'.join(legend)}")
-        
-        comparison_stats = {
-            'correlations': {},
-            'relative_ratios': {},
-            'dominance_analysis': {}
-        }
-        
-        # Calculate correlations between legend means
-        mean_columns = [f"{name}_Mean" for name in legend_names]
-        available_means = [col for col in mean_columns if col in time_series_df.columns]
-        
-        if len(available_means) > 1:
-            corr_matrix = time_series_df[available_means].corr()
-            comparison_stats['correlations'] = corr_matrix.to_dict()
-        
-        # Calculate relative ratios (if applicable)
-        if len(available_means) == 2:
-            col1, col2 = available_means
-            ratio_series = time_series_df[col1] / (time_series_df[col2] + 1e-10)  # Add small value to avoid division by zero
-            comparison_stats['relative_ratios'] = {
-                f'{col1}_to_{col2}_ratio': {
-                    'mean': float(ratio_series.mean()),
-                    'std': float(ratio_series.std()),
-                    'median': float(ratio_series.median())
-                }
-            }
-        
-        # Dominance analysis (which legend has higher values most of the time)
-        if len(available_means) > 1:
-            dominance = {}
-            for i, col1 in enumerate(available_means):
-                for j, col2 in enumerate(available_means):
-                    if i < j:  # Avoid duplicate comparisons
-                        dominance_count = (time_series_df[col1] > time_series_df[col2]).sum()
-                        total_points = len(time_series_df)
-                        dominance[f'{col1}_dominates_{col2}'] = dominance_count / total_points
-            
-            comparison_stats['dominance_analysis'] = dominance
-        
-        return comparison_stats
+        return result_stat
 
     def clear_cache(self):
         """Clear processor cache."""
         self._cache.clear()
+

--- a/ionerdss/nerdss_analysis/data/processors/transitions.py
+++ b/ionerdss/nerdss_analysis/data/processors/transitions.py
@@ -17,6 +17,10 @@ class TransitionProcessor:
     
     def __init__(self):
         self._cache = {}
+        self._selected_dirs = []
+
+    def configure(self, selected_dirs: List[str]):
+        self._selected_dirs = selected_dirs
     
     def aggregate_matrices(self, transition_data: Dict[str, Any]) -> np.ndarray:
         """Aggregate transition matrices across simulations."""

--- a/ionerdss/nerdss_analysis/data/processors/utils.py
+++ b/ionerdss/nerdss_analysis/data/processors/utils.py
@@ -1,0 +1,103 @@
+from typing import List, Dict, Any, Tuple, Optional
+import re
+
+# Configure logging, 
+import logging
+# inherit from the global level (should be setup in main)
+logger = logging.getLogger(__name__)
+
+# ========================================================================
+# Helper functions
+# ========================================================================
+
+def parse_histogram_complex(species_data_str: str) -> Optional[Dict[str, int]]:
+    """
+    Parse species data string and return a dictionary with species and counts.
+    
+    Parameters:
+        species_data_str (str): Species data like "A: 2. B: 1."
+        
+    Returns:
+        Optional[Dict[str, int]]: Dictionary mapping species to counts, or None if parsing fails
+        
+    Example:
+        >>> parse_histogram_complex("A: 2. B: 1.")
+        {'A': 2, 'B': 1}
+        
+        >>> parse_histogram_complex("A: 3. A: 1.")  # Duplicate species
+        {'A': 4}
+    """
+    species_data = species_data_str.split()
+    species_dict = {}
+
+    try:
+        for i in range(0, len(species_data), 2):
+            species_name = species_data[i].strip(":")
+            species_count = int(species_data[i + 1].strip("."))
+            species_dict[species_name] = species_dict.get(species_name, 0) + species_count
+    except (IndexError, ValueError) as e:
+        logger.warning(f"Error parsing species data '{species_data_str}': {e}")
+        return None
+
+    return species_dict
+     
+def parse_histogram_line(line: str) -> Tuple[Optional[int], Optional[Dict[str, int]]]:
+    """
+    Parse a single complex line and return a dictionary with species and counts.
+    
+    Parameters:
+        line (str): A line of text containing complex data
+        
+    Returns:
+        Tuple[Optional[int], Optional[Dict[str, int]]]: 
+            A tuple containing the count of complexes and a dictionary mapping species to counts
+            
+    Example:
+        >>> parse_complex_line("5 A: 2. B: 1.")
+        (5, {'A': 2, 'B': 1})
+    """
+    match = re.match(r"(\d+)\s+([\w\.\s:]+)", line)
+    if not match:
+        return None, None
+
+    count = int(match.group(1))
+    species_data_str = match.group(2)
+    
+    # Use the new parsing function
+    species_dict = parse_histogram_complex(species_data_str)
+    
+    if species_dict is None:
+        logger.warning(f"Error parsing complex line '{line}': failed to parse species data")
+        return None, None
+
+    return count, species_dict
+
+def filter_by_time_frame(data: Dict[str, Any], time_frame: Tuple[float, float]) -> Dict[str, Any]:
+        """Filter data by time frame."""
+        start, end = time_frame
+        filtered_indices = [
+            i for i, t in enumerate(data["time_series"]) 
+            if start <= t <= end
+        ]
+        
+        return {
+            "time_series": [data["time_series"][i] for i in filtered_indices],
+            "complexes": [data["complexes"][i] for i in filtered_indices]
+        }
+
+def align_time_series(all_data: List[Dict[str, Any]]) -> List[float]:
+        """
+        Find common time points across simulations.
+        TODO: Should return the aligned time series and indices for each trajectory.
+        """
+
+        time_series_list = [data['time_series'] for data in all_data if data['time_series']]
+        if not time_series_list:
+            return []
+        
+        # Use the shortest time series to ensure alignment
+        min_length = min(len(ts) for ts in time_series_list)
+        common_time_points = time_series_list[0][:min_length]
+        
+        # Initialize result dictionary
+        return common_time_points

--- a/ionerdss/nerdss_analysis/data/processors/utils.py
+++ b/ionerdss/nerdss_analysis/data/processors/utils.py
@@ -81,13 +81,19 @@ def filter_by_time_frame(data: Dict[str, Any], time_frame: Tuple[float, float]) 
         ]
         
         return {
-            "time_series": [data["time_series"][i] for i in filtered_indices],
+            "time_series": [data["Time (s)"][i] for i in filtered_indices],
             "complexes": [data["complexes"][i] for i in filtered_indices]
         }
 
 def align_time_series(all_data: List[Dict[str, Any]]) -> List[float]:
         """
         Find common time points across simulations.
+        all_data is in the format of:
+        [
+            {'Time (s)':[...], '...':[...]},
+            {'Time (s)':[...], '...':[...]},
+            ...
+        ]
         TODO: Should return the aligned time series and indices for each trajectory.
         """
 

--- a/ionerdss/nerdss_analysis/data/processors/utils.py
+++ b/ionerdss/nerdss_analysis/data/processors/utils.py
@@ -89,15 +89,20 @@ def align_time_series(all_data: List[Dict[str, Any]]) -> List[float]:
         """
         Find common time points across simulations.
         all_data is in the format of:
+        ```
         [
             {'Time (s)':[...], '...':[...]},
             {'Time (s)':[...], '...':[...]},
             ...
         ]
-        TODO: Should return the aligned time series and indices for each trajectory.
+        ```
         """
 
-        time_series_list = [data['Time (s)'] for data in all_data if data['Time (s)']]
+        # TODO: Should return the aligned time series and indices for each trajectory.
+        # TODO: Now this function may take inputs of type list or pandas.Dataframe. 
+        #     This should be unified
+
+        time_series_list = [data['Time (s)'] for data in all_data]
         if not time_series_list:
             return []
         

--- a/ionerdss/nerdss_analysis/data/processors/utils.py
+++ b/ionerdss/nerdss_analysis/data/processors/utils.py
@@ -76,7 +76,7 @@ def filter_by_time_frame(data: Dict[str, Any], time_frame: Tuple[float, float]) 
         """Filter data by time frame."""
         start, end = time_frame
         filtered_indices = [
-            i for i, t in enumerate(data["time_series"]) 
+            i for i, t in enumerate(data["Time (s)"]) 
             if start <= t <= end
         ]
         
@@ -91,7 +91,7 @@ def align_time_series(all_data: List[Dict[str, Any]]) -> List[float]:
         TODO: Should return the aligned time series and indices for each trajectory.
         """
 
-        time_series_list = [data['time_series'] for data in all_data if data['time_series']]
+        time_series_list = [data['Time (s)'] for data in all_data if data['Time (s)']]
         if not time_series_list:
             return []
         

--- a/ionerdss/nerdss_analysis/data_readers.py
+++ b/ionerdss/nerdss_analysis/data_readers.py
@@ -357,31 +357,6 @@ class DataIO:
         
         return result
     
-    def get_multiple_copy_numbers(self, sim_dirs: List[str]) -> List[Optional[pd.DataFrame]]:
-        """
-        Get copy numbers data from multiple simulation directories.
-        
-        Parameters:
-            sim_dirs (List[str]): List of simulation directories
-            
-        Returns:
-            List[Optional[pd.DataFrame]]: List of DataFrames, with None for simulations that failed
-        """
-        logger.info(f"Reading copy numbers from {len(sim_dirs)} simulations")
-        return [self.get_copy_numbers(sim_dir) for sim_dir in sim_dirs]
-    
-    def get_multiple_histogram_complexes(self, sim_dirs: List[str]) -> List[Dict[str, Any]]:
-        """
-        Get histogram complex data from multiple simulation directories.
-        
-        Parameters:
-            sim_dirs (List[str]): List of simulation directories
-            
-        Returns:
-            List[Dict[str, Any]]: List of dictionaries containing time series and complex data
-        """
-        logger.info(f"Reading histogram complexes from {len(sim_dirs)} simulations")
-        return [self.get_histogram_complexes(sim_dir) for sim_dir in sim_dirs]
     
     def get_multiple_transition_matrices(self, sim_dirs: List[str], time_frame: Optional[Tuple[float, float]] = None) -> List[Tuple[Optional[np.ndarray], Optional[Dict[int, List[float]]]]]:
         """

--- a/ionerdss/nerdss_analysis/data_readers.py
+++ b/ionerdss/nerdss_analysis/data_readers.py
@@ -18,32 +18,6 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def read_copy_numbers(sim_dir: str) -> Optional[pd.DataFrame]:
-    """
-    Read species copy numbers vs time data from a simulation directory.
-    
-    Parameters:
-        sim_dir (str): Path to the simulation directory
-        
-    Returns:
-        Optional[pd.DataFrame]: DataFrame containing the data, or None if file not found
-    """
-    data_file = os.path.join(sim_dir, "DATA", "copy_numbers_time.dat")
-    
-    if not os.path.exists(data_file):
-        logger.warning(f"Copy numbers file not found: {data_file}")
-        return None
-    
-    try:
-        df = pd.read_csv(data_file)
-        df.rename(columns=lambda x: x.strip(), inplace=True)
-        logger.debug(f"Successfully read copy numbers from {data_file}")
-        return df
-    except Exception as e:
-        logger.error(f"Error reading copy numbers from {data_file}: {e}")
-        return None
-
-
 
 
 
@@ -354,28 +328,6 @@ class DataIO:
         if self._cache_enabled:
             self._cache = {}
             logger.info("DataIO cache cleared")
-        
-    def get_copy_numbers(self, sim_dir: str) -> Optional[pd.DataFrame]:
-        """
-        Get species copy numbers data from a simulation directory, using cache if available.
-        
-        Parameters:
-            sim_dir (str): Path to the simulation directory
-            
-        Returns:
-            Optional[pd.DataFrame]: DataFrame containing the data, or None if file not found
-        """
-        cache_key = (sim_dir, "copy_numbers")
-        if self._cache_enabled and cache_key in self._cache:
-            logger.debug(f"Cache hit for copy numbers: {sim_dir}")
-            return self._cache[cache_key]
-        
-        result = read_copy_numbers(sim_dir)
-        if result is not None and self._cache_enabled:
-            self._cache[cache_key] = result
-            logger.debug(f"Cached copy numbers for: {sim_dir}")
-        
-        return result
     
     def get_transition_matrix(self, sim_dir: str, time_frame: Optional[Tuple[float, float]] = None) -> Tuple[Optional[np.ndarray], Optional[Dict[int, List[float]]]]:
         """

--- a/ionerdss/nerdss_analysis/plotting/core.py
+++ b/ionerdss/nerdss_analysis/plotting/core.py
@@ -122,7 +122,7 @@ class PlotConfigure:
             'user_file_name': kwargs.get('user_file_name', None)
         }
         
-        return plot_line_speciescopy_vs_time(**params)
+        return plot_line_speciescopy_vs_time(data, **params)
     
     def line_assembly_size_vs_time(self, data: 'Data', assembly_type: str = "maximum", 
                                  legend: List[str] = None, **kwargs):
@@ -138,11 +138,11 @@ class PlotConfigure:
         }
         
         if assembly_type == "maximum":
-            return plot_line_maximum_assembly_size_vs_time(legend=legend or [], **base_params)
+            return plot_line_maximum_assembly_size_vs_time(data, legend=legend or [], **base_params)
         elif assembly_type == "average":
-            return plot_line_average_assembly_size_vs_time(legend=legend or [], **base_params)
+            return plot_line_average_assembly_size_vs_time(data, legend=legend or [], **base_params)
         elif assembly_type == "fraction":
-            return plot_line_fraction_of_monomers_assembled_vs_time(legend=legend or [], **base_params)
+            return plot_line_fraction_of_monomers_assembled_vs_time(data, legend=legend or [], **base_params)
         else:
             raise ValueError(f"Unknown assembly_type: {assembly_type}")
     
@@ -159,7 +159,7 @@ class PlotConfigure:
             'show_type': kwargs.get('show_type', 'both')
         }
         
-        return plot_complex_count_vs_time(**params)
+        return plot_complex_count_vs_time(data, **params)
     
     def line_free_energy_vs_size(self, data: 'Data', **kwargs):
         """Create free energy vs cluster size line plot."""
@@ -224,7 +224,7 @@ class PlotConfigure:
             'figure_size': kwargs.get('figure_size', self._config['figure_size'])
         }
         
-        return plot_hist_complex_species_size(**params)
+        return plot_hist_complex_species_size(data, **params)
     
     def histogram_monomer_count(self, data: 'Data', legend: List[str], **kwargs):
         """Create monomer count histogram."""
@@ -262,7 +262,7 @@ class PlotConfigure:
             'figure_size': kwargs.get('figure_size', self._config['figure_size'])
         }
         
-        return plot_stackedhist_complex_species_size(**params)
+        return plot_stackedhist_complex_species_size(data, **params)
     
     # 3D plot methods
     def histogram_3d_complex_size(self, data: 'Data', legend: List[str], **kwargs):
@@ -281,7 +281,7 @@ class PlotConfigure:
             'figure_size': kwargs.get('figure_size', self._config['figure_size'])
         }
         
-        return plot_hist_complex_species_size_3d(**params)
+        return plot_hist_complex_species_size_3d(data, **params)
     
     def histogram_3d_monomer_count(self, data: 'Data', legend: List[str], **kwargs):
         """Create 3D monomer count histogram."""
@@ -299,7 +299,7 @@ class PlotConfigure:
             'figure_size': kwargs.get('figure_size', self._config['figure_size'])
         }
         
-        return plot_hist_monomer_counts_vs_complex_size_3d(**params)
+        return plot_hist_monomer_counts_vs_complex_size_3d(data, **params)
     
     # Heatmap methods
     def heatmap_complex_size_time(self, data: 'Data', legend: List[str], **kwargs):
@@ -318,7 +318,7 @@ class PlotConfigure:
             'figure_size': kwargs.get('figure_size', self._config['figure_size'])
         }
         
-        return plot_heatmap_complex_species_size(**params)
+        return plot_heatmap_complex_species_size(data, **params)
     
     def heatmap_monomer_count_time(self, data: 'Data', legend: List[str], **kwargs):
         """Create monomer count vs time heatmap."""
@@ -336,7 +336,7 @@ class PlotConfigure:
             'figure_size': kwargs.get('figure_size', self._config['figure_size'])
         }
         
-        return plot_heatmap_monomer_counts_vs_complex_size(**params)
+        return plot_heatmap_monomer_counts_vs_complex_size(data, **params)
     
     def heatmap_species_correlation(self, data: 'Data', legend: List[str], **kwargs):
         """Create species A vs species B heatmap."""
@@ -354,7 +354,7 @@ class PlotConfigure:
             'figure_size': kwargs.get('figure_size', self._config['figure_size'])
         }
         
-        return plot_heatmap_species_a_vs_species_b(**params)
+        return plot_heatmap_species_a_vs_species_b(data, **params)
     
     # Utility methods
     def save_current_plot(self, filename: str, **kwargs):

--- a/ionerdss/nerdss_analysis/plotting/heatmap_plots.py
+++ b/ionerdss/nerdss_analysis/plotting/heatmap_plots.py
@@ -11,6 +11,8 @@ import seaborn as sns
 import re
 from typing import List, Optional, Tuple, Dict, Any
 
+from ..data.core import Data
+
 # Import the data reading utilities
 from ..data_readers import (
     DataIO,
@@ -24,6 +26,7 @@ def format_sig(x, sig=3):
 
 
 def plot_heatmap_complex_species_size(
+    data:Data,
     save_dir: str,
     simulations_index: list,
     legend: list,
@@ -61,13 +64,13 @@ def plot_heatmap_complex_species_size(
     
     # Read data from each simulation
     for sim_dir in selected_dirs:
-        data = data_io.get_histogram_complexes(sim_dir)
-        if not data["time_series"]:
+        single_data = data.get_histogram_data(sim_dir)
+        if not data["Time (s)"]:
             continue
         
         sim_data = []
-        for i, time in enumerate(data["time_series"]):
-            for count, species_dict in data["complexes"][i]:
+        for i, time in enumerate(single_data["Time (s)"]):
+            for count, species_dict in single_data["complexes"][i]:
                 size = sum(species_dict.get(s, 0) for s in legend if s in species_dict)
                 sim_data.extend([(time, size)] * count)
                 
@@ -121,6 +124,7 @@ def plot_heatmap_complex_species_size(
 
 
 def plot_heatmap_monomer_counts_vs_complex_size(
+    data:Data,
     save_dir: str,
     simulations_index: list,
     legend: list,
@@ -158,13 +162,13 @@ def plot_heatmap_monomer_counts_vs_complex_size(
     
     # Read data from each simulation
     for sim_dir in selected_dirs:
-        data = data_io.get_histogram_complexes(sim_dir)
-        if not data["time_series"]:
+        single_data = data.get_histogram_data(sim_dir)
+        if not data["Time (s)"]:
             continue
         
         sim_data = []
-        for i, time in enumerate(data["time_series"]):
-            for count, species_dict in data["complexes"][i]:
+        for i, time in enumerate(single_data["Time (s)"]):
+            for count, species_dict in single_data["complexes"][i]:
                 size = sum(species_dict.get(s, 0) for s in legend if s in species_dict)
                 # Weight by size (number of monomers)
                 sim_data.append((time, size, count * size))
@@ -220,6 +224,7 @@ def plot_heatmap_monomer_counts_vs_complex_size(
 
 
 def plot_heatmap_species_a_vs_species_b(
+    data:Data,
     save_dir: str,
     simulations_index: list,
     legend: list,
@@ -260,12 +265,12 @@ def plot_heatmap_species_a_vs_species_b(
     
     # Read data from each simulation
     for sim_dir in selected_dirs:
-        data = data_io.get_histogram_complexes(sim_dir)
-        if not data["time_series"]:
+        single_data = data.get_histogram_data(sim_dir)
+        if not data["Time (s)"]:
             continue
         
         sim_data = []
-        for complexes in data["complexes"]:
+        for complexes in single_data["complexes"]:
             for count, species_dict in complexes:
                 x = species_dict.get(species_x, 0)
                 y = species_dict.get(species_y, 0)

--- a/ionerdss/nerdss_analysis/plotting/histogram_plots.py
+++ b/ionerdss/nerdss_analysis/plotting/histogram_plots.py
@@ -273,7 +273,7 @@ def plot_stackedhist_complex_species_size(
     # Read data from each simulation
     for sim_dir in selected_dirs:
         singledata = data.get_histogram_data(sim_dir)
-        if not singledata["time_series"]:
+        if not singledata["Time (s)"]:
             continue
             
         # Filter by time frame if specified
@@ -393,11 +393,11 @@ def plot_hist_complex_species_size_3d(
     # First pass to collect all sizes and times
     for sim_dir in selected_dirs:
         single_data = data.get_histogram_data(sim_dir)
-        if not single_data["time_series"]:
+        if not single_data["Time (s)"]:
             continue
         
         sim_data = []
-        for i, time in enumerate(single_data["time_series"]):
+        for i, time in enumerate(single_data["Time (s)"]):
             for count, species_dict in single_data["complexes"][i]:
                 size = sum(species_dict.get(s, 0) for s in legend if s in species_dict)
                 sim_data.extend([(time, size)] * count)

--- a/ionerdss/nerdss_analysis/plotting/histogram_plots.py
+++ b/ionerdss/nerdss_analysis/plotting/histogram_plots.py
@@ -11,6 +11,9 @@ import seaborn as sns
 import re
 from typing import List, Optional, Tuple, Dict, Any
 
+from ..data.core import Data
+
+
 # Import the data reading utilities
 from ..data_readers import (
     DataIO,
@@ -20,6 +23,7 @@ from ..data_readers import (
 data_io = DataIO()
 
 def plot_hist_complex_species_size(
+    data:Data,
     save_dir: str,
     simulations_index: list,
     legend: list,
@@ -49,31 +53,14 @@ def plot_hist_complex_species_size(
     plot_data_dir = os.path.join(save_dir, "figure_plot_data")
     os.makedirs(plot_data_dir, exist_ok=True)
 
-    all_sizes_per_sim = []
-    all_sizes_combined = []
-
     # Get the simulation directories to process
     selected_dirs = [simulations_dir[idx] for idx in simulations_index]
     
     # Read data for each simulation
-    for sim_dir in selected_dirs:
-        data = data_io.get_histogram_complexes(sim_dir)
-        if not data["time_series"]:
-            continue
-            
-        # Filter by time frame if specified
-        if time_frame:
-            data = filter_by_time_frame(data, time_frame)
-            
-        sim_sizes = []
-        for complexes in data["complexes"]:
-            for count, species_dict in complexes:
-                complex_size = sum(species_dict[species] for species in legend if species in species_dict)
-                sim_sizes.extend([complex_size] * count)
-                
-        if sim_sizes:
-            all_sizes_per_sim.append(sim_sizes)
-            all_sizes_combined.extend(sim_sizes)
+    all_sizes_per_sim = data.get_complex_sizes(selected_dirs)
+    all_sizes_combined = []
+    for sim_sizes in all_sizes_per_sim:
+        all_sizes_combined.extend(sim_sizes)
 
     if not all_sizes_per_sim:
         print("No valid simulation data found.")
@@ -135,6 +122,7 @@ def plot_hist_complex_species_size(
 
 
 def plot_hist_monomer_counts_vs_complex_size(
+    data:Data,
     save_dir: str,
     simulations_index: list,
     legend: list,
@@ -166,32 +154,15 @@ def plot_hist_monomer_counts_vs_complex_size(
     """
     plot_data_dir = os.path.join(save_dir, "figure_plot_data")
     os.makedirs(plot_data_dir, exist_ok=True)
-    
-    all_sizes_per_sim = []
-    all_sizes_combined = []
 
     # Get the simulation directories to process
     selected_dirs = [simulations_dir[idx] for idx in simulations_index]
 
     # Step 1: Read data for each simulation
-    for sim_dir in selected_dirs:
-        data = data_io.get_histogram_complexes(sim_dir)
-        if not data["time_series"]:
-            continue
-            
-        # Filter by time frame if specified
-        if time_frame:
-            data = filter_by_time_frame(data, time_frame)
-            
-        sim_sizes = []
-        for complexes in data["complexes"]:
-            for count, species_dict in complexes:
-                complex_size = sum(species_dict[species] for species in legend if species in species_dict)
-                sim_sizes.extend([complex_size] * count)
-                
-        if sim_sizes:
-            all_sizes_per_sim.append(sim_sizes)
-            all_sizes_combined.extend(sim_sizes)
+    all_sizes_per_sim = data.get_complex_sizes(selected_dirs)
+    all_sizes_combined = []
+    for sim_sizes in all_sizes_per_sim:
+        all_sizes_combined.extend(sim_sizes)
 
     if not all_sizes_per_sim:
         print("No valid simulation data found.")
@@ -254,6 +225,7 @@ def plot_hist_monomer_counts_vs_complex_size(
 
 
 def plot_stackedhist_complex_species_size(
+    data:Data,
     save_dir: str,
     simulations_index: list,
     legend: list,
@@ -300,17 +272,17 @@ def plot_stackedhist_complex_species_size(
     
     # Read data from each simulation
     for sim_dir in selected_dirs:
-        data = data_io.get_histogram_complexes(sim_dir)
-        if not data["time_series"]:
+        singledata = data.get_histogram_data(sim_dir)
+        if not singledata["time_series"]:
             continue
             
         # Filter by time frame if specified
         if time_frame:
-            data = filter_by_time_frame(data, time_frame)
+            singledata = filter_by_time_frame(singledata, time_frame)
             
         histogram = {cond: [] for cond in y_conditions}
         
-        for complexes in data["complexes"]:
+        for complexes in singledata["complexes"]:
             for count, species_dict in complexes:
                 x = species_dict.get(x_species, 0)
                 y = species_dict.get(y_var, 0)
@@ -385,6 +357,7 @@ def plot_stackedhist_complex_species_size(
     print(f"Stacked histogram data saved to {os.path.join(plot_data_dir, 'stacked_hist_complex_species_size.csv')}")
 
 def plot_hist_complex_species_size_3d(
+    data:Data,
     save_dir: str,
     simulations_index: list,
     legend: list,
@@ -419,13 +392,13 @@ def plot_hist_complex_species_size_3d(
     
     # First pass to collect all sizes and times
     for sim_dir in selected_dirs:
-        data = data_io.get_histogram_complexes(sim_dir)
-        if not data["time_series"]:
+        single_data = data.get_histogram_data(sim_dir)
+        if not single_data["time_series"]:
             continue
         
         sim_data = []
-        for i, time in enumerate(data["time_series"]):
-            for count, species_dict in data["complexes"][i]:
+        for i, time in enumerate(single_data["time_series"]):
+            for count, species_dict in single_data["complexes"][i]:
                 size = sum(species_dict.get(s, 0) for s in legend if s in species_dict)
                 sim_data.extend([(time, size)] * count)
                 
@@ -496,6 +469,7 @@ def plot_hist_complex_species_size_3d(
 
 
 def plot_hist_monomer_counts_vs_complex_size_3d(
+    data:Data,
     save_dir: str,
     simulations_index: list,
     legend: list,
@@ -533,13 +507,13 @@ def plot_hist_monomer_counts_vs_complex_size_3d(
     
     # Read data from each simulation
     for sim_dir in selected_dirs:
-        data = data_io.get_histogram_complexes(sim_dir)
-        if not data["time_series"]:
+        single_data = data.get_histogram_data(sim_dir)
+        if not data["Time (s)"]:
             continue
         
         sim_data = []
-        for i, time in enumerate(data["time_series"]):
-            for count, species_dict in data["complexes"][i]:
+        for i, time in enumerate(single_data["Time (s)"]):
+            for count, species_dict in single_data["complexes"][i]:
                 size = sum(species_dict.get(s, 0) for s in legend if s in species_dict)
                 # Weight by size (number of monomers)
                 sim_data.append((time, size, count * size))

--- a/ionerdss/nerdss_analysis/plotting/line_plots.py
+++ b/ionerdss/nerdss_analysis/plotting/line_plots.py
@@ -10,6 +10,8 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 from typing import List, Optional, Tuple, Dict, Any
 
+from ..data.core import Data
+
 # Import the data reading utilities
 from ..data_readers import (
     DataIO,
@@ -20,6 +22,7 @@ from ..data_readers import (
 data_io = DataIO()
 
 def plot_line_speciescopy_vs_time(
+    data: Data,
     save_dir: str,
     simulations_index: list,
     legend: list,
@@ -51,7 +54,7 @@ def plot_line_speciescopy_vs_time(
     selected_dirs = [simulations_dir[idx] for idx in simulations_index]
     
     # Read data using the data IO utility
-    all_sim_data = data_io.get_multiple_copy_numbers(selected_dirs)
+    all_sim_data = data.get_copy_numbers_data(selected_dirs)
     
     # Filter out None values (failed reads)
     all_sim_data = [df for df in all_sim_data if df is not None]
@@ -126,6 +129,7 @@ def plot_line_speciescopy_vs_time(
 
 
 def plot_line_maximum_assembly_size_vs_time(
+    data:Data,
     save_dir: str,
     simulations_index: list,
     legend: list,
@@ -154,14 +158,14 @@ def plot_line_maximum_assembly_size_vs_time(
     
     # Read histogram complex data for each simulation
     for sim_dir in selected_dirs:
-        data = data_io.get_histogram_complexes(sim_dir)
-        if not data["time_series"]:
+        single_data = data.get_histogram_data(sim_dir)
+        if not data["Time (s)"]:
             continue
             
-        time_series = data["time_series"]
+        time_series = single_data["Time (s)"]
         max_assembly_sizes = []
         
-        for complexes in data["complexes"]:
+        for complexes in single_data["complexes"]:
             max_size = max([sum(complex_dict.values()) for count, complex_dict in complexes], default=0)
             max_assembly_sizes.append(max_size)
             
@@ -218,6 +222,7 @@ def plot_line_maximum_assembly_size_vs_time(
 
 
 def plot_line_average_assembly_size_vs_time(
+    data:Data,
     save_dir: str,
     simulations_index: list,
     legend: list,
@@ -246,14 +251,14 @@ def plot_line_average_assembly_size_vs_time(
     
     # Read data for each simulation
     for sim_dir in selected_dirs:
-        data = data_io.get_histogram_complexes(sim_dir)
-        if not data["time_series"]:
+        single_data = data.get_histogram_data(sim_dir)
+        if not data["Time (s)"]:
             continue
             
-        time_series = data["time_series"]
+        time_series = single_data["Time (s)"]
         condition_results = {condition: [] for condition in legend}
         
-        for complexes in data["complexes"]:
+        for complexes in single_data["complexes"]:
             avg_sizes = compute_average_assembly_size(complexes, legend)
             for cond in legend:
                 condition_results[cond].append(avg_sizes.get(cond, 0))
@@ -312,6 +317,7 @@ def plot_line_average_assembly_size_vs_time(
 
 
 def plot_line_fraction_of_monomers_assembled_vs_time(
+    data:Data,
     save_dir: str,
     simulations_index: list,
     legend: list,
@@ -340,14 +346,14 @@ def plot_line_fraction_of_monomers_assembled_vs_time(
     
     # Read data for each simulation
     for sim_dir in selected_dirs:
-        data = data_io.get_histogram_complexes(sim_dir)
-        if not data["time_series"]:
+        single_data = data.get_histogram_data(sim_dir)
+        if not single_data["Time (s)"]:
             continue
             
-        time_series = data["time_series"]
+        time_series = single_data["Time (s)"]
         fraction_results = {condition: [] for condition in legend}
         
-        for complexes in data["complexes"]:
+        for complexes in single_data["complexes"]:
             for cond in legend:
                 selected_counts = 0
                 total_counts = 0
@@ -418,6 +424,7 @@ def plot_line_fraction_of_monomers_assembled_vs_time(
 
 
 def plot_complex_count_vs_time(
+    data:Data,
     save_dir: str,
     simulations_index: list,
     target_complexes: list,
@@ -447,14 +454,14 @@ def plot_complex_count_vs_time(
     
     # Read data for each simulation
     for sim_dir in selected_dirs:
-        data = data_io.get_histogram_complexes(sim_dir)
-        if not data["time_series"]:
+        single_data = data.get_histogram_data(sim_dir)
+        if not single_data["time_series"]:
             continue
             
-        time_series = data["time_series"]
+        time_series = single_data["time_series"]
         complex_counts = {complex_type: [] for complex_type in target_complexes}
         
-        for complexes in data["complexes"]:
+        for complexes in single_data["complexes"]:
             # Initialize counts for this time point
             current_counts = {complex_type: 0 for complex_type in target_complexes}
             

--- a/ionerdss/nerdss_analysis/plotting/line_plots.py
+++ b/ionerdss/nerdss_analysis/plotting/line_plots.py
@@ -57,7 +57,7 @@ def plot_line_speciescopy_vs_time(
     all_sim_data = data.get_copy_numbers_data(selected_dirs)
     
     # Filter out None values (failed reads)
-    all_sim_data = [df for df in all_sim_data if df is not None]
+    all_sim_data = [df for df in all_sim_data['dataframes'] if df is not None]
 
     if not all_sim_data:
         print("No valid simulation data found.")
@@ -455,10 +455,10 @@ def plot_complex_count_vs_time(
     # Read data for each simulation
     for sim_dir in selected_dirs:
         single_data = data.get_histogram_data(sim_dir)
-        if not single_data["time_series"]:
+        if not single_data["Time (s)"]:
             continue
             
-        time_series = single_data["time_series"]
+        time_series = single_data["Time (s)"]
         complex_counts = {complex_type: [] for complex_type in target_complexes}
         
         for complexes in single_data["complexes"]:

--- a/ionerdss/nerdss_analysis/plotting/three_d_plots.py
+++ b/ionerdss/nerdss_analysis/plotting/three_d_plots.py
@@ -11,6 +11,8 @@ from mpl_toolkits.mplot3d import Axes3D
 import seaborn as sns
 from typing import List, Optional, Tuple, Dict, Any
 
+from ..data.core import Data
+
 # Import the data reading utilities
 from ..data_readers import (
     DataIO,
@@ -19,6 +21,7 @@ from ..data_readers import (
 data_io = DataIO()
 
 def plot_hist_complex_species_size_3d(
+    data:Data,
     save_dir: str,
     simulations_index: list,
     legend: list,
@@ -53,13 +56,13 @@ def plot_hist_complex_species_size_3d(
     
     # First pass to collect all sizes and times
     for sim_dir in selected_dirs:
-        data = data_io.get_histogram_complexes(sim_dir)
-        if not data["time_series"]:
+        single_data = data.get_histogram_data(sim_dir)
+        if not data["Time (s)"]:
             continue
         
         sim_data = []
-        for i, time in enumerate(data["time_series"]):
-            for count, species_dict in data["complexes"][i]:
+        for i, time in enumerate(single_data["Time (s)"]):
+            for count, species_dict in single_data["complexes"][i]:
                 size = sum(species_dict.get(s, 0) for s in legend if s in species_dict)
                 sim_data.extend([(time, size)] * count)
                 
@@ -130,6 +133,7 @@ def plot_hist_complex_species_size_3d(
 
 
 def plot_hist_monomer_counts_vs_complex_size_3d(
+    data:Data,
     save_dir: str,
     simulations_index: list,
     legend: list,
@@ -167,13 +171,13 @@ def plot_hist_monomer_counts_vs_complex_size_3d(
     
     # Read data from each simulation
     for sim_dir in selected_dirs:
-        data = data_io.get_histogram_complexes(sim_dir)
+        single_data = data.get_histogram_data(sim_dir)
         if not data["time_series"]:
             continue
         
         sim_data = []
-        for i, time in enumerate(data["time_series"]):
-            for count, species_dict in data["complexes"][i]:
+        for i, time in enumerate(single_data["time_series"]):
+            for count, species_dict in single_data["complexes"][i]:
                 size = sum(species_dict.get(s, 0) for s in legend if s in species_dict)
                 # Weight by size (number of monomers)
                 sim_data.append((time, size, count * size))

--- a/ionerdss/nerdss_analysis/plotting/three_d_plots.py
+++ b/ionerdss/nerdss_analysis/plotting/three_d_plots.py
@@ -172,11 +172,11 @@ def plot_hist_monomer_counts_vs_complex_size_3d(
     # Read data from each simulation
     for sim_dir in selected_dirs:
         single_data = data.get_histogram_data(sim_dir)
-        if not data["time_series"]:
+        if not single_data["Time (s)"]:
             continue
         
         sim_data = []
-        for i, time in enumerate(single_data["time_series"]):
+        for i, time in enumerate(single_data["Time (s)"]):
             for count, species_dict in single_data["complexes"][i]:
                 size = sum(species_dict.get(s, 0) for s in legend if s in species_dict)
                 # Weight by size (number of monomers)


### PR DESCRIPTION
Basic usage:
```python
analysis = ion.Analysis(workdir+"/nerdss_output/") # workdir should end with nerdss_output
# to get data and customize plots
stats = analysis.data.histogram.calculate_time_series_statistics(legends=['A: 1.'], legend_names=['A1'])
plt.plot(stats['Time (s)'], stats['A1']['mean'])
# to use legacy plots
# plot from histogram
analysis.plot_figure('line', x='time', y='count', legend=['A: 1.'])
# plot from copy number
fig = analysis.plot_figure(figure_type='line', x='time', y='species', legend=[['A(m)']])
```

Develop notes:

Histogram reading and Copynumber reading now have a unified 
reading pipeline: Processor.read().
Transition matrix reading is not modified.
TODO: Based on Histogram reading and Copynumber reading, further 
develop data reading for other output files including transition 
matrix.
TODO: The goal is to remove dependency on DataIO which is a legacy 
from the previous refactoring. It violates the structure of analysis 
module. The structure should be:

```
\_
  |_ __init__.py (handel import)
  |_ analysis.py (basic Analysis class)
  |_ plot_figures.py (basic plotting class)
  |_
  |_ data
      |_ __init__.py
      |_ core.py (data handling class)
      |_ processors
           |_ data reading modules, each output file has a module
           |_ ...
  |_ plotting
      |_ plotting modules, each type of figure has a module
      |_ ...
  |_ legacy
      |_ API for backward compatibility
      |_ ...
```